### PR TITLE
Fixed location of Google's GoPacket library (was moved to github)

### DIFF
--- a/brassfork.go
+++ b/brassfork.go
@@ -1,9 +1,10 @@
 package main
 
+// Corrected location of gopacket 9/29/17
 import (
-	"code.google.com/p/gopacket"
-	"code.google.com/p/gopacket/layers"
-	"code.google.com/p/gopacket/pcap"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
 	"encoding/json"
 	"flag"
 	"fmt"


### PR DESCRIPTION
I came across your tool while doing some pcap analysis (and using Gephi) - really appreciate you open sourcing your work.  Thank you!  It wouldn't compile cleanly but the fix was simple.  I thought I'd offer it up. Thanks! 